### PR TITLE
Add translators, translation strategy and tests (major design changes)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: tests
+
+on:
+    push:
+    pull_request:
+    schedule:
+        - cron: '0 0 * * *'
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: true
+            matrix:
+                php: [8.0]
+                laravel: [8.*]
+                stability: [prefer-stable]
+                include:
+                    - laravel: 8.*
+                      testbench: 6.*
+
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
+
+        steps:
+            - name: checkout
+              uses: actions/checkout@v2
+
+            - name: Cache dependencies
+              uses: actions/cache@v1
+              with:
+                  path: ~/.composer/cache/files
+                  key: dependencies-laravel-${{ matrix.laravel }}-php-${{
+                      matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  tools: composer:v2
+                  coverage: none
+
+            - name: Install dependencies
+              run: |
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer update --${{ matrix.stability }} --prefer-dist --no-suggest
+
+            - name: Execute tests
+              run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,15 @@
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.3",
         "illuminate/support": "^8",
-        "illuminate/console": "^8.57",
-        "illuminate/database": "^8.57",
-        "astrotomic/laravel-translatable": "^11.0"
+        "illuminate/console": "^8.0",
+        "illuminate/database": "^8.0"
     },
     "require-dev": {
+        "astrotomic/laravel-translatable": "^11.0",
         "phpunit/phpunit": "^9.4",
-        "mockery/mockery": "^1.4"
+        "mockery/mockery": "^1.4",
+        "illuminate/testing": "^8.0",
+        "orchestra/testbench": "^6.0"
     },
     "extra": {
         "laravel": {

--- a/config/deeplable.php
+++ b/config/deeplable.php
@@ -10,7 +10,7 @@ return [
     | to DeepL.
     |
     */
-    'api_url' => 'https://api-free.deepl.com/v2/translate',
+    'api_url' => 'https://api-free.deepl.com/v2',
 
     /*
     |--------------------------------------------------------------------------

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Fjord Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="APP_DEBUG" value="true"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="MAIL_MAILER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/src/Commands/DeeplableCommand.php
+++ b/src/Commands/DeeplableCommand.php
@@ -2,9 +2,10 @@
 
 namespace AwStudio\Deeplable\Commands;
 
-use AwStudio\Deeplable\Facades\Deepl;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+use AwStudio\Deeplable\Facades\Translator;
 
 class DeeplableCommand extends Command
 {
@@ -23,68 +24,51 @@ class DeeplableCommand extends Command
     protected $description = 'Generate missing translations via DeepL.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int
      */
     public function handle()
     {
+        $fallbackLocale = config('translatable.fallback_locale');
+        $locales = $this->getLocales();
         $models = config('deeplable.translated_models');
 
         foreach ($models as $model) {
-            $instance = new $model;
-
-            $all = $instance->get();
-
-            $this->translateCollection($all);
+            $this->translateCollection((new $model)->get(), $locales, $fallbackLocale);
         }
+    }
+
+    /**
+     * Get locales that should be translated to.
+     *
+     * @return array
+     */
+    public function getLocales()
+    {
+        return collect($this->argument('locale') ?: config('translatable.locales'))
+            ->filter(fn ($locale) => $locale != config('translatable.fallback_locale'))
+            ->toArray();
     }
 
     /**
      * Translate a collection of models.
      *
      * @param  Collection $models
+     * @param array $locales
+     * @param string $fallbackLocale
      * @return void
      */
-    public function translateCollection(Collection $models): void
+    public function translateCollection(Collection $models, $locales, $fallbackLocale): void
     {
-        $locales = collect($this->argument('locale') ?: config('translatable.locales'));
+        foreach ($models as $model) {
+            $translator = Translator::for($model);
 
-        $models->each(function ($model) use ($locales) {
-            // skip if there is no default translation
-            if (! $model->hasTranslation()) {
-                return;
+            foreach ($locales as $locale) {
+                $translator->translate($model, $locale, $fallbackLocale);
             }
 
-            $locales->each(function ($locale) use ($model) {
-                // skip default language
-                if ($locale == config('translatable.fallback_locale')) {
-                    return;
-                }
-                // Generate all "fully" missing translations
-                if (! $model->hasTranslation($locale)) {
-                    Deepl::translateModel($model, $locale);
-                }
-                // look for single missing attributes
-                $translatedAttributes = collect($model->getTranslationsArray()[$locale]);
-
-                $translatedAttributes->each(function ($value, $attribute) use ($model, $locale) {
-                    if ($value != '' && $value != '<p></p>') {
-                        return;
-                    }
-                    Deepl::translateModelAttribute($model, $attribute, $locale);
-                });
-            });
-        });
+            $model->save();
+        }
     }
 }

--- a/src/Commands/DeeplableCommand.php
+++ b/src/Commands/DeeplableCommand.php
@@ -2,10 +2,9 @@
 
 namespace AwStudio\Deeplable\Commands;
 
+use AwStudio\Deeplable\Facades\Translator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Illuminate\Database\Eloquent\Model;
-use AwStudio\Deeplable\Facades\Translator;
 
 class DeeplableCommand extends Command
 {

--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -41,8 +41,8 @@ class Deepl
     public function translate(string $string, string $targetLang, string | null $sourceLanguage = null): string
     {
         // Avoid translating empty strings.
-        if (!$string) {
-            return "";
+        if (! $string) {
+            return '';
         }
 
         $body = [
@@ -53,7 +53,7 @@ class Deepl
         ];
 
         $content = $this->apiCall('POST', 'translate', [
-            'query' => $body
+            'query' => $body,
         ]);
 
         $translation = $content['translations'][0]['text'];
@@ -73,7 +73,7 @@ class Deepl
     {
         $response = $this->client->request(
             $method,
-            $this->apiUrl."/".$action,
+            $this->apiUrl.'/'.$action,
             $params
         );
 

--- a/src/DeeplableServiceProvider.php
+++ b/src/DeeplableServiceProvider.php
@@ -2,13 +2,12 @@
 
 namespace AwStudio\Deeplable;
 
-use AwStudio\Deeplable\Deepl;
+use Astrotomic\Translatable\Contracts\Translatable;
+use AwStudio\Deeplable\Commands\DeeplableCommand;
+use AwStudio\Deeplable\Translators\AstrotomicTranslator;
+use AwStudio\Deeplable\Translators\Resolver;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
-use AwStudio\Deeplable\Translators\Resolver;
-use AwStudio\Deeplable\Commands\DeeplableCommand;
-use Astrotomic\Translatable\Contracts\Translatable;
-use AwStudio\Deeplable\Translators\AstrotomicTranslator;
 
 class DeeplableServiceProvider extends ServiceProvider
 {

--- a/src/DeeplableServiceProvider.php
+++ b/src/DeeplableServiceProvider.php
@@ -2,8 +2,13 @@
 
 namespace AwStudio\Deeplable;
 
-use AwStudio\Deeplable\Commands\DeeplableCommand;
+use AwStudio\Deeplable\Deepl;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
+use AwStudio\Deeplable\Translators\Resolver;
+use AwStudio\Deeplable\Commands\DeeplableCommand;
+use Astrotomic\Translatable\Contracts\Translatable;
+use AwStudio\Deeplable\Translators\AstrotomicTranslator;
 
 class DeeplableServiceProvider extends ServiceProvider
 {
@@ -14,8 +19,26 @@ class DeeplableServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('laravel-deeplable', function ($app) {
-            return new Deepl;
+        $this->app->singleton('deeplable.api', function ($app) {
+            $apiToken = $app['config']['deeplable.api_token'];
+            $apiUrl = $app['config']['deeplable.api_url'];
+            $fallbackLocale = $app['config']['translatable.fallback_locale'];
+
+            return new Deepl($apiToken, $apiUrl, $fallbackLocale);
+        });
+
+        $this->app->singleton('deeplable.translator', function ($app) {
+            $resolver = new Resolver();
+
+            $resolver->register(Translatable::class, function () use ($app) {
+                return new AstrotomicTranslator($app['deeplable.api']);
+            });
+
+            $resolver->strategy(function (Model $model) {
+                return Translatable::class;
+            });
+
+            return $resolver;
         });
     }
 

--- a/src/Facades/Translator.php
+++ b/src/Facades/Translator.php
@@ -4,7 +4,7 @@ namespace AwStudio\Deeplable\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class Deepl extends Facade
+class Translator extends Facade
 {
     /**
      * Get the registered name of the component.
@@ -13,6 +13,6 @@ class Deepl extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'deeplable.api';
+        return 'deeplable.translator';
     }
 }

--- a/src/Translators/AstrotomicTranslator.php
+++ b/src/Translators/AstrotomicTranslator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace AwStudio\Deeplable\Translators;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AstrotomicTranslator extends BaseTranslator
+{
+    /**
+     * Translate the given model attribute.
+     *
+     * @param Model $model
+     * @param string $attribute
+     * @param string $locale
+     * @param string $translation
+     * @return void
+     */
+    protected function translateAttribute(Model $model, $attribute, $locale, $translation)
+    {
+        $model->translateOrNew($locale)->setAttribute($attribute, $translation);
+    }
+
+    /**
+     * Get a list of the translated attributes of a model.
+     *
+     * @param Model $model
+     * @param string $locale
+     * @return array
+     */
+    public function getTranslatedAttributes(Model $model, $locale)
+    {
+        return array_keys($model->getTranslationsArray()[$locale] ?? []);
+    }
+
+    /**
+     * Translate all translated attributes of a model.
+     *
+     * @param Model $model
+     * @param array $attributes
+     * @param  string                        $targetLang
+     * @param  string|null                   $sourceLanguage
+     * @return void
+     */
+    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null)
+    {
+        if (! $model->hasTranslation($sourceLanguage)) {
+            return;
+        }
+
+        return parent::translate($model, $targetLang, $sourceLanguage);
+    }
+}

--- a/src/Translators/BaseTranslator.php
+++ b/src/Translators/BaseTranslator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace AwStudio\Deeplable\Translators;
+
+use AwStudio\Deeplable\Deepl;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class BaseTranslator
+{
+    /**
+     * Translate the given model attribute.
+     *
+     * @param Model $model
+     * @param string $attribute
+     * @param string $locale
+     * @param string $translation
+     * @return void
+     */
+    abstract protected function translateAttribute(Model $model, $attribute, $locale, $translation);
+
+    /**
+     * Get a list of the translated attributes of a model.
+     *
+     * @param Model $model
+     * @param string $locale
+     * @return array
+     */
+    abstract public function getTranslatedAttributes(Model $model, $locale);
+
+    /**
+     * Create new Translator instance.
+     *
+     * @param Deepl $api
+     * @return void
+     */
+    public function __construct(
+        protected Deepl $api
+    ) {
+        //
+    }
+
+    /**
+     * Translate all translated attributes of a model.
+     *
+     * @param Model $model
+     * @param array $attributes
+     * @param  string                        $targetLang
+     * @param  string|null                   $sourceLanguage
+     * @return void
+     */
+    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null)
+    {
+        $translatedAttributes = $this->getTranslatedAttributes($model, $sourceLanguage);
+
+        if (empty($translatedAttributes)) {
+            return;
+        }
+
+        $this->translateAttributes(
+            $model,
+            $translatedAttributes,
+            $targetLang,
+            $sourceLanguage
+        );
+    }
+
+    /**
+     * Translate a list of attributes.
+     *
+     * @param Model $model
+     * @param array $attributes
+     * @param  string                        $targetLang
+     * @param  string|null                   $sourceLanguage
+     * @return void
+     */
+    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null)
+    {
+        foreach ($attributes as $attribute) {
+            $translation = $this->api->translate(
+                $model->getAttribute($attribute),
+                $targetLang,
+                $sourceLanguage
+            );
+
+            $this->translateAttribute($model, $attribute, $targetLang, $translation);
+        }
+    }
+}

--- a/src/Translators/Resolver.php
+++ b/src/Translators/Resolver.php
@@ -4,7 +4,6 @@ namespace AwStudio\Deeplable\Translators;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-use AwStudio\Deeplable\Translators\BaseTranslator;
 
 class Resolver
 {

--- a/src/Translators/Resolver.php
+++ b/src/Translators/Resolver.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace AwStudio\Deeplable\Translators;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use AwStudio\Deeplable\Translators\BaseTranslator;
+
+class Resolver
+{
+    /**
+     * Translator resolver.
+     *
+     * @var array[Closure]
+     */
+    protected $resolvers = [];
+
+    /**
+     * Resolved translators.
+     *
+     * @var array[BaseTranslator]
+     */
+    protected $resolved = [];
+
+    /**
+     * Register a translator resolver.
+     *
+     * @param string $abstract
+     * @param Closure $resolver
+     * @return void
+     */
+    public function register($abstract, Closure $resolver)
+    {
+        $this->resolvers[$abstract] = $resolver;
+    }
+
+    /**
+     * Get a translator.
+     *
+     * @param string $alias
+     * @return BaseTranslator|null
+     */
+    public function get($alias)
+    {
+        if (array_key_exists($alias, $this->resolved)) {
+            return $this->resolved[$alias];
+        }
+
+        if (! array_key_exists($alias, $this->resolvers)) {
+            return;
+        }
+
+        return $this->resolved[$alias] = call_user_func($this->resolvers[$alias]);
+    }
+
+    /**
+     * Get translator for the given model.
+     *
+     * @param Model $model
+     * @return void
+     */
+    public function for(Model $model)
+    {
+        return $this->get(
+            call_user_func($this->strategy, $model)
+        );
+    }
+
+    /**
+     * Set strategy.
+     *
+     * @param Closure $closure
+     * @return void
+     */
+    public function strategy(Closure $closure)
+    {
+        $this->strategy = $closure;
+    }
+}

--- a/tests/AstrotomicTranslatorTest.php
+++ b/tests/AstrotomicTranslatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests;
+
+use Mockery;
+use AwStudio\Deeplable\Deepl;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Astrotomic\Translatable\Translatable;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Testing\AssertableJsonString;
+use AwStudio\Deeplable\Translators\BaseTranslator;
+use Astrotomic\Translatable\TranslatableServiceProvider;
+use AwStudio\Deeplable\Translators\AstrotomicTranslator;
+use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
+
+class AstrotomicTranslatorTest extends TestCase
+{
+    public function setUp():void
+    {
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            TranslatableServiceProvider::class,
+        ];
+    }
+
+    public function testItTranslatesModelAttributes()
+    {
+        $api = Mockery::mock(Deepl::class);
+        $api->shouldReceive('translate')->andReturn('Hallo Welt');
+        $translator = new AstrotomicTranslator($api);
+
+        $post = new DummyTranslatablePost([
+            'en' => ['title' => 'Hello World']
+        ]);
+
+        $translator->translateAttributes($post, ['title'], 'de', 'en');
+
+        $this->app->setLocale('de');
+        $this->assertSame($post->title, 'Hallo Welt');
+    }
+
+    public function testItGetsTranslatedAttributes()
+    {
+        $api = Mockery::mock(Deepl::class);
+        $api->shouldReceive('translate')->andReturn('Hallo Welt');
+        $translator = new AstrotomicTranslator($api);
+
+        $post = new DummyTranslatablePost([
+            'en' => ['title' => 'Hello World']
+        ]);
+
+        $this->assertEquals(['title'], $translator->getTranslatedAttributes($post, 'en'));
+    }
+}
+
+class DummyTranslatablePostTranslation extends Model
+{
+    public $table = 'post_translations';
+    protected $fillable = ['title'];
+    public $timestamps = false;
+}
+
+class DummyTranslatablePost extends Model implements TranslatableContract
+{
+    use Translatable;
+
+    public $table = 'posts';
+    protected $translationModel = DummyTranslatablePostTranslation::class;
+    protected $translatedAttributes = ['title'];
+    public $timestamps = false;
+}

--- a/tests/AstrotomicTranslatorTest.php
+++ b/tests/AstrotomicTranslatorTest.php
@@ -2,22 +2,18 @@
 
 namespace Tests;
 
-use Mockery;
-use AwStudio\Deeplable\Deepl;
-use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Eloquent\Model;
-use Astrotomic\Translatable\Translatable;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Testing\AssertableJsonString;
-use AwStudio\Deeplable\Translators\BaseTranslator;
-use Astrotomic\Translatable\TranslatableServiceProvider;
-use AwStudio\Deeplable\Translators\AstrotomicTranslator;
 use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
+use Astrotomic\Translatable\Translatable;
+use Astrotomic\Translatable\TranslatableServiceProvider;
+use AwStudio\Deeplable\Deepl;
+use AwStudio\Deeplable\Translators\AstrotomicTranslator;
+use Illuminate\Database\Eloquent\Model;
+use Mockery;
+use Orchestra\Testbench\TestCase;
 
 class AstrotomicTranslatorTest extends TestCase
 {
-    public function setUp():void
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -36,7 +32,7 @@ class AstrotomicTranslatorTest extends TestCase
         $translator = new AstrotomicTranslator($api);
 
         $post = new DummyTranslatablePost([
-            'en' => ['title' => 'Hello World']
+            'en' => ['title' => 'Hello World'],
         ]);
 
         $translator->translateAttributes($post, ['title'], 'de', 'en');
@@ -52,7 +48,7 @@ class AstrotomicTranslatorTest extends TestCase
         $translator = new AstrotomicTranslator($api);
 
         $post = new DummyTranslatablePost([
-            'en' => ['title' => 'Hello World']
+            'en' => ['title' => 'Hello World'],
         ]);
 
         $this->assertEquals(['title'], $translator->getTranslatedAttributes($post, 'en'));

--- a/tests/BaseTranslatorTest.php
+++ b/tests/BaseTranslatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests;
+
+use AwStudio\Deeplable\Deepl;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Testing\AssertableJsonString;
+use AwStudio\Deeplable\Translators\BaseTranslator;
+
+class BaseTranslatorTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testTranslateAttributesCallsTranslateAttribute()
+    {
+        $api = Mockery::mock(Deepl::class);
+        $api->shouldReceive('translate')->twice()->andReturn('bar');
+        $post = Mockery::mock(Model::class);
+        $post->shouldReceive('getAttribute')->andReturn('foo');
+        $post->shouldReceive('jsonSerialize');
+        $translator = new DummyTranslatorMock($api);
+        $translator->translateAttributes($post, ['title', 'text'], 'de', 'en');
+
+        $this->assertSame($translator->calledTimes, 2);
+        $translator->calledParams[0]->assertFragment([
+            'attribute' => 'title',
+            'locale' => 'de',
+            'translation' => 'bar'
+        ]);
+        $translator->calledParams[1]->assertFragment([
+            'attribute' => 'text',
+            'locale' => 'de',
+            'translation' => 'bar'
+        ]);
+    }
+
+    public function testTranslateAttributesCallsApi()
+    {
+        $api = Mockery::mock(Deepl::class);
+        $api->shouldReceive('translate')->once()->withArgs([
+            'foo', 'de', 'en'
+        ]);
+        $post = Mockery::mock(Model::class);
+        $post->shouldReceive('getAttribute')->withArgs(['title'])->andReturn('foo');
+        $translator = new DummyTranslatorMock($api);
+        $translator->translateAttributes($post, ['title'], 'de', 'en');
+    }
+}
+
+class DummyTranslatorMock extends BaseTranslator
+{
+    public $calledTimes = 0;
+    public $calledParams = [];
+
+    public function getTranslatedAttributes(Model $model, $locale)
+    {
+        return ['title', 'text'];
+    }
+
+    protected function translateAttribute(Model $model, $attribute, $locale, $translation)
+    {
+        $this->calledTimes++;
+        $this->calledParams []= new AssertableJsonString([
+            'model' => $model,
+            'attribute' => $attribute,
+            'locale' => $locale,
+            'translation' => $translation
+        ]);
+    }
+}

--- a/tests/BaseTranslatorTest.php
+++ b/tests/BaseTranslatorTest.php
@@ -3,11 +3,11 @@
 namespace Tests;
 
 use AwStudio\Deeplable\Deepl;
-use Mockery;
-use PHPUnit\Framework\TestCase;
+use AwStudio\Deeplable\Translators\BaseTranslator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Testing\AssertableJsonString;
-use AwStudio\Deeplable\Translators\BaseTranslator;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 
 class BaseTranslatorTest extends TestCase
 {
@@ -30,12 +30,12 @@ class BaseTranslatorTest extends TestCase
         $translator->calledParams[0]->assertFragment([
             'attribute' => 'title',
             'locale' => 'de',
-            'translation' => 'bar'
+            'translation' => 'bar',
         ]);
         $translator->calledParams[1]->assertFragment([
             'attribute' => 'text',
             'locale' => 'de',
-            'translation' => 'bar'
+            'translation' => 'bar',
         ]);
     }
 
@@ -43,7 +43,7 @@ class BaseTranslatorTest extends TestCase
     {
         $api = Mockery::mock(Deepl::class);
         $api->shouldReceive('translate')->once()->withArgs([
-            'foo', 'de', 'en'
+            'foo', 'de', 'en',
         ]);
         $post = Mockery::mock(Model::class);
         $post->shouldReceive('getAttribute')->withArgs(['title'])->andReturn('foo');
@@ -65,11 +65,11 @@ class DummyTranslatorMock extends BaseTranslator
     protected function translateAttribute(Model $model, $attribute, $locale, $translation)
     {
         $this->calledTimes++;
-        $this->calledParams []= new AssertableJsonString([
+        $this->calledParams [] = new AssertableJsonString([
             'model' => $model,
             'attribute' => $attribute,
             'locale' => $locale,
-            'translation' => $translation
+            'translation' => $translation,
         ]);
     }
 }

--- a/tests/DeeplableCommandTest.php
+++ b/tests/DeeplableCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests;
+
+use Mockery;
+use AwStudio\Deeplable\Deepl;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Astrotomic\Translatable\Translatable;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Testing\AssertableJsonString;
+use AwStudio\Deeplable\Translators\BaseTranslator;
+use Astrotomic\Translatable\TranslatableServiceProvider;
+use AwStudio\Deeplable\Translators\AstrotomicTranslator;
+use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
+use AwStudio\Deeplable\DeeplableServiceProvider;
+
+class DeeplableCommandTest extends TestCase
+{
+    public function setUp():void
+    {
+        parent::setUp();
+        Schema::create('posts', fn (Blueprint $table) => $table->id());
+        Schema::create('post_translations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('dummy_post_id');
+            $table->string('locale');
+            $table->string('title');
+        });
+    }
+
+    public function tearDown(): void
+    {
+        Schema::drop('posts');
+        Schema::drop('post_translations');
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            DeeplableServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $config = $app['config'];
+        $config->set('deeplable.api_url', '');
+        $config->set('deeplable.api_token', '');
+        $config->set('deeplable.translated_models', [
+            DummyPost::class
+        ]);
+        $config->set('translatable.fallback_locale', 'en');
+        $config->set('translatable.locales', [
+            'en', 'de',
+        ]);
+    }
+
+    public function test_deeplable_run_command()
+    {
+        $api = Mockery::mock(Deepl::class);
+        $api->shouldReceive('translate')->andReturn('bar');
+
+        $this->app->singleton('deeplable.api', function () use ($api) {
+            return $api;
+        });
+
+        DummyPost::create(['en' => ['title' => 'foo']]);
+        DummyPost::create(['en' => ['title' => 'foo']]);
+        DummyPost::create(['en' => ['title' => 'foo']]);
+
+        $this->app->setLocale('de');
+        foreach (DummyPost::all() as $post) {
+            $this->assertSame(null, $post->title);
+        }
+
+        $this->app->setLocale('en');
+        $this->artisan('deeplable:run', ['locale' => 'de']);
+
+        $this->app->setLocale('de');
+        foreach (DummyPost::all() as $post) {
+            $this->assertSame('bar', $post->title);
+        }
+    }
+}
+
+class DummyPostTranslation extends Model
+{
+    public $table = 'post_translations';
+    protected $fillable = ['title'];
+    public $timestamps = false;
+}
+
+class DummyPost extends Model implements TranslatableContract
+{
+    use Translatable;
+
+    public $table = 'posts';
+    protected $translationModel = DummyPostTranslation::class;
+    protected $translatedAttributes = ['title'];
+    public $timestamps = false;
+}

--- a/tests/DeeplableCommandTest.php
+++ b/tests/DeeplableCommandTest.php
@@ -2,23 +2,19 @@
 
 namespace Tests;
 
-use Mockery;
-use AwStudio\Deeplable\Deepl;
-use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Eloquent\Model;
-use Astrotomic\Translatable\Translatable;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Testing\AssertableJsonString;
-use AwStudio\Deeplable\Translators\BaseTranslator;
-use Astrotomic\Translatable\TranslatableServiceProvider;
-use AwStudio\Deeplable\Translators\AstrotomicTranslator;
 use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
+use Astrotomic\Translatable\Translatable;
+use AwStudio\Deeplable\Deepl;
 use AwStudio\Deeplable\DeeplableServiceProvider;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use Orchestra\Testbench\TestCase;
 
 class DeeplableCommandTest extends TestCase
 {
-    public function setUp():void
+    public function setUp(): void
     {
         parent::setUp();
         Schema::create('posts', fn (Blueprint $table) => $table->id());
@@ -50,7 +46,7 @@ class DeeplableCommandTest extends TestCase
         $config->set('deeplable.api_url', '');
         $config->set('deeplable.api_token', '');
         $config->set('deeplable.translated_models', [
-            DummyPost::class
+            DummyPost::class,
         ]);
         $config->set('translatable.fallback_locale', 'en');
         $config->set('translatable.locales', [


### PR DESCRIPTION
This pr adds translators, translation strategies and tests to the package. This includes major design changes. How the features are used is explained as follows. Furthermore an upgrade guide describes the breaking changes.

### Translators

Translators have the purpose to bind a translatable attribute to a model. A build in example is the `AstrotomicTranslator` that updates models that are translated by the [astrotomic/laravel-translatable](https://github.com/Astrotomic/laravel-translatable) package.

#### Creating A Translator

A translator must extend the `AwStudio\Deeplable\Translators\BaseTranslator` class which has 2 abstract methods:

```php
class AstrotomicTranslator
{
    protected function translateAttribute(Model $model, $attribute, $locale, $translation)
    {
        $model->translateOrNew($locale)->setAttribute($attribute, $translation);
    }

    public function getTranslatedAttributes(Model $model, $locale)
    {
        return array_keys($model->getTranslationsArray()[$locale] ?? []);
    }
}
```

#### Registering The Translator

A translator may be registered in a Service Provider like this:

```php
use AwStudio\Deeplable\Translators\Resolver;
use Astrotomic\Translatable\Contracts\Translatable;

public function register()
{
    Translator::register(Translatable::class, function () {
            return new AstrotomicTranslator($this->app['deeplable.api']);
    });
}
```

#### Using The Translator

The translator can then be used like this:

```php
use AwStudio\Deeplable\Facades\Translator;
use Astrotomic\Translatable\Contracts\Translatable;

Translator::get(Translatable::class)->translate($post, 'de', 'en'); // Translates the whole model from en to de
Translator::get(Translatable::class)->translateAttributes($post, ['title', 'text'], 'de', 'en'); // Translates attributes title and text from en to de
```

### Translation Strategy

Given the case that different models need different translators, a translation strategy can be specified in a service provider like this:

```php
use AwStudio\Deeplable\Facades\Translator;
use AwStudio\Deeplable\Translators\Resolver;
use Astrotomic\Translatable\Contracts\Translatable;

public function register()
{
    Translator::strategy(function(Model $model) {
        if($model instanceof Translatable) {
            return Translatable::class;
        }
        // something else...
    });
}
```

The correct translator can now be received like this:

```php
Translator::for($post)->translate(...);
```

### Upgrade Guide

The config key `deeplable.api_url` changed: 
```diff
-https://api-free.deepl.com/v2/translate
+https://api-free.deepl.com/v2
```