### PR TITLE
update deepl class apiUrl default param.

### DIFF
--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -24,7 +24,7 @@ class Deepl
      */
     public function __construct(
         protected string $apiToken,
-        protected string $apiUrl = 'https://api-free.deepl.com/v2/translate',
+        protected string $apiUrl = 'https://api-free.deepl.com/v2',
         protected string $fallbackLocale = 'en'
     ) {
         $this->client = new Client();


### PR DESCRIPTION
with the old default param, the api action would be in the url twice, when the apiCall method is called. But only if the class would be used directly without the service provider. Maybe the defaults in the class constructor should be removed entirely?