### PR TITLE
Add force option

### DIFF
--- a/src/Commands/DeeplableCommand.php
+++ b/src/Commands/DeeplableCommand.php
@@ -2,11 +2,11 @@
 
 namespace AwStudio\Deeplable\Commands;
 
+use AwStudio\Deeplable\Facades\Translator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use AwStudio\Deeplable\Facades\Translator;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class DeeplableCommand extends Command
 {

--- a/src/Commands/DeeplableCommand.php
+++ b/src/Commands/DeeplableCommand.php
@@ -2,18 +2,20 @@
 
 namespace AwStudio\Deeplable\Commands;
 
-use AwStudio\Deeplable\Facades\Translator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use AwStudio\Deeplable\Facades\Translator;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
 class DeeplableCommand extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'deeplable:run {locale?}';
+    protected $name = 'deeplable:run';
 
     /**
      * The console command description.
@@ -21,6 +23,30 @@ class DeeplableCommand extends Command
      * @var string
      */
     protected $description = 'Generate missing translations via DeepL.';
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['locale', InputArgument::OPTIONAL, 'The locale of the language to translate to'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Whether existing records are to be overwritten', null],
+        ];
+    }
 
     /**
      * Execute the console command.
@@ -60,11 +86,13 @@ class DeeplableCommand extends Command
      */
     public function translateCollection(Collection $models, $locales, $fallbackLocale): void
     {
+        $force = $this->hasOption('force') && $this->option('force');
+
         foreach ($models as $model) {
             $translator = Translator::for($model);
 
             foreach ($locales as $locale) {
-                $translator->translate($model, $locale, $fallbackLocale);
+                $translator->translate($model, $locale, $fallbackLocale, $force);
             }
 
             $model->save();

--- a/src/Contracts/Translator.php
+++ b/src/Contracts/Translator.php
@@ -13,9 +13,10 @@ interface Translator
      * @param array $attributes
      * @param  string                        $targetLang
      * @param  string|null                   $sourceLanguage
+     * @param bool $force
      * @return void
      */
-    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null);
+    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null, bool $force = true);
 
     /**
      * Translate a list of attributes.
@@ -24,7 +25,8 @@ interface Translator
      * @param array $attributes
      * @param  string                        $targetLang
      * @param  string|null                   $sourceLanguage
+     * @param bool $force
      * @return void
      */
-    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null);
+    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null, bool $force = true);
 }

--- a/src/Traits/Deeplable.php
+++ b/src/Traits/Deeplable.php
@@ -11,11 +11,12 @@ trait Deeplable
      *
      * @param  string      $targetLang
      * @param  string|null $sourceLanguage
+     * @param bool $force
      * @return void
      */
-    public function translateTo(string $targetLang, string | null $sourceLanguage = null)
+    public function translateTo(string $targetLang, string | null $sourceLanguage = null, bool $force = true)
     {
-        Translator::for($this)->translate($this, $targetLang, $sourceLanguage);
+        Translator::for($this)->translate($this, $targetLang, $sourceLanguage, $force);
 
         $this->save();
     }
@@ -26,11 +27,12 @@ trait Deeplable
      * @param  string      $attr
      * @param  string      $targetLang
      * @param  string|null $sourceLanguage
+     * @param bool $force
      * @return void
      */
-    public function translateAttributeTo(string $attr, string $targetLang, string | null $sourceLanguage = null)
+    public function translateAttributeTo(string $attr, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
     {
-        $this->translateAttributesTo([$attr], $targetLang, $sourceLanguage);
+        $this->translateAttributesTo([$attr], $targetLang, $sourceLanguage, $force);
     }
 
     /**
@@ -39,9 +41,10 @@ trait Deeplable
      * @param  string      $attr
      * @param  string      $targetLang
      * @param  string|null $sourceLanguage
+     * @param bool $force
      * @return void
      */
-    public function translateAttributesTo(array $attributes, string $targetLang, string | null $sourceLanguage = null)
+    public function translateAttributesTo(array $attributes, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
     {
         Translator::for($this)->translateAttributes($this, $attributes, $targetLang, $sourceLanguage);
 

--- a/src/Translators/AstrotomicTranslator.php
+++ b/src/Translators/AstrotomicTranslator.php
@@ -13,11 +13,19 @@ class AstrotomicTranslator extends BaseTranslator
      * @param string $attribute
      * @param string $locale
      * @param string $translation
+     * @param bool $force
      * @return void
      */
-    protected function translateAttribute(Model $model, $attribute, $locale, $translation)
+    protected function translateAttribute(Model $model, $attribute, $locale, $translation, bool $force = true)
     {
-        $model->translateOrNew($locale)->setAttribute($attribute, $translation);
+        $translationModel = $model->translateOrNew($locale);
+
+        // Ignore attribute when it has a value and it should not be overriten.
+        if (! $force && $translationModel->getAttribute($attribute)) {
+            return;
+        }
+
+        $translationModel->setAttribute($attribute, $translation);
     }
 
     /**
@@ -39,14 +47,15 @@ class AstrotomicTranslator extends BaseTranslator
      * @param array $attributes
      * @param  string                        $targetLang
      * @param  string|null                   $sourceLanguage
+     * @param bool $force
      * @return void
      */
-    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null)
+    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
     {
         if (! $model->hasTranslation($sourceLanguage)) {
             return;
         }
 
-        return parent::translate($model, $targetLang, $sourceLanguage);
+        return parent::translate($model, $targetLang, $sourceLanguage, $force);
     }
 }

--- a/src/Translators/BaseTranslator.php
+++ b/src/Translators/BaseTranslator.php
@@ -17,7 +17,7 @@ abstract class BaseTranslator implements Translator
      * @param string $translation
      * @return void
      */
-    abstract protected function translateAttribute(Model $model, $attribute, $locale, $translation);
+    abstract protected function translateAttribute(Model $model, $attribute, $locale, $translation, bool $force = true);
 
     /**
      * Get a list of the translated attributes of a model.
@@ -49,7 +49,7 @@ abstract class BaseTranslator implements Translator
      * @param  string|null                   $sourceLanguage
      * @return void
      */
-    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null)
+    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
     {
         $translatedAttributes = $this->getTranslatedAttributes($model, $sourceLanguage);
 
@@ -61,7 +61,8 @@ abstract class BaseTranslator implements Translator
             $model,
             $translatedAttributes,
             $targetLang,
-            $sourceLanguage
+            $sourceLanguage,
+            $force
         );
     }
 
@@ -74,7 +75,7 @@ abstract class BaseTranslator implements Translator
      * @param  string|null                   $sourceLanguage
      * @return void
      */
-    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null)
+    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
     {
         foreach ($attributes as $attribute) {
             $translation = $this->api->translate(
@@ -83,7 +84,7 @@ abstract class BaseTranslator implements Translator
                 $sourceLanguage
             );
 
-            $this->translateAttribute($model, $attribute, $targetLang, $translation);
+            $this->translateAttribute($model, $attribute, $targetLang, $translation, $force);
         }
     }
 }

--- a/tests/BaseTranslatorTest.php
+++ b/tests/BaseTranslatorTest.php
@@ -62,7 +62,7 @@ class DummyTranslatorMock extends BaseTranslator
         return ['title', 'text'];
     }
 
-    protected function translateAttribute(Model $model, $attribute, $locale, $translation)
+    protected function translateAttribute(Model $model, $attribute, $locale, $translation, bool $force = true)
     {
         $this->calledTimes++;
         $this->calledParams [] = new AssertableJsonString([

--- a/tests/DeeplableCommandTest.php
+++ b/tests/DeeplableCommandTest.php
@@ -92,11 +92,11 @@ class DeeplableCommandTest extends TestCase
 
         DummyPost::create([
             'en' => ['title' => 'foo'],
-            'de' => ['title' => 'baz']
+            'de' => ['title' => 'baz'],
         ]);
         DummyPost::create([
             'en' => ['title' => 'foo'],
-            'de' => ['title' => 'baz']
+            'de' => ['title' => 'baz'],
         ]);
 
         // Assuming force is disabled by default.

--- a/tests/DeeplableCommandTest.php
+++ b/tests/DeeplableCommandTest.php
@@ -80,6 +80,47 @@ class DeeplableCommandTest extends TestCase
             $this->assertSame('bar', $post->title);
         }
     }
+
+    public function test_deeplable_run_command_with_force_option()
+    {
+        $api = Mockery::mock(Deepl::class);
+        $api->shouldReceive('translate')->andReturn('bar');
+
+        $this->app->singleton('deeplable.api', function () use ($api) {
+            return $api;
+        });
+
+        DummyPost::create([
+            'en' => ['title' => 'foo'],
+            'de' => ['title' => 'baz']
+        ]);
+        DummyPost::create([
+            'en' => ['title' => 'foo'],
+            'de' => ['title' => 'baz']
+        ]);
+
+        // Assuming force is disabled by default.
+        $this->app->setLocale('en');
+        $this->artisan('deeplable:run', ['locale' => 'de']);
+        $this->app->setLocale('de');
+        foreach (DummyPost::all() as $post) {
+            $this->assertSame('baz', $post->title);
+        }
+
+        $this->app->setLocale('en');
+        $this->artisan('deeplable:run', ['locale' => 'de', '--force' => false]);
+        $this->app->setLocale('de');
+        foreach (DummyPost::all() as $post) {
+            $this->assertSame('baz', $post->title);
+        }
+
+        $this->app->setLocale('en');
+        $this->artisan('deeplable:run', ['locale' => 'de', '--force' => true]);
+        $this->app->setLocale('de');
+        foreach (DummyPost::all() as $post) {
+            $this->assertSame('bar', $post->title);
+        }
+    }
 }
 
 class DummyPostTranslation extends Model


### PR DESCRIPTION
This pr adds the option to enable/disabled overriting existing values by passing a boolean as the last parameter to all translator methods. A `--force` option may be added to the `deeplable:run` command:

```shell
php artisan deeplable:run de --force
```