### PR TITLE
Adds queueable job

### DIFF
--- a/src/Commands/DeeplableCommand.php
+++ b/src/Commands/DeeplableCommand.php
@@ -2,13 +2,13 @@
 
 namespace AwStudio\Deeplable\Commands;
 
-use Illuminate\Console\Command;
-use Illuminate\Support\Collection;
-use GuzzleHttp\Exception\GuzzleException;
 use AwStudio\Deeplable\Facades\Translator;
 use AwStudio\Deeplable\Jobs\TranslateModelJob;
-use Symfony\Component\Console\Input\InputOption;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class DeeplableCommand extends Command
 {
@@ -82,9 +82,9 @@ class DeeplableCommand extends Command
     /**
      * Translate a collection of models.
      *
-     * @param  Collection $models
-     * @param  array      $locales
-     * @param  string     $fallbackLocale
+     * @param  Collection  $models
+     * @param  array  $locales
+     * @param  string  $fallbackLocale
      * @return void
      */
     public function translateCollection(Collection $models, $locales, $fallbackLocale): void

--- a/src/Commands/DeeplableCommand.php
+++ b/src/Commands/DeeplableCommand.php
@@ -2,12 +2,13 @@
 
 namespace AwStudio\Deeplable\Commands;
 
-use AwStudio\Deeplable\Facades\Translator;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Symfony\Component\Console\Input\InputArgument;
+use GuzzleHttp\Exception\GuzzleException;
+use AwStudio\Deeplable\Facades\Translator;
+use AwStudio\Deeplable\Jobs\TranslateModelJob;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
 class DeeplableCommand extends Command
 {
@@ -46,6 +47,7 @@ class DeeplableCommand extends Command
     {
         return [
             ['force', null, InputOption::VALUE_NONE, 'Whether existing records are to be overwritten', null],
+            ['queue', null, InputOption::VALUE_NONE, 'Whether the job should be queued', null],
         ];
     }
 
@@ -88,15 +90,20 @@ class DeeplableCommand extends Command
     public function translateCollection(Collection $models, $locales, $fallbackLocale): void
     {
         $force = $this->hasOption('force') && $this->option('force');
+        $shouldQueue = $this->hasOption('queue') && $this->option('queue');
 
         foreach ($models as $model) {
             $translator = Translator::for($model);
 
             foreach ($locales as $locale) {
-                try {
-                    $translator->translate($model, $locale, $fallbackLocale, $force);
-                } catch (GuzzleException $e) {
-                    $this->error('Failed to translate '.get_class($model));
+                if ($shouldQueue) {
+                    TranslateModelJob::dispatch($model, $locale, $fallbackLocale, $force);
+                } else {
+                    try {
+                        $translator->translate($model, $locale, $fallbackLocale, $force);
+                    } catch (GuzzleException $e) {
+                        $this->error('Failed to translate '.get_class($model));
+                    }
                 }
             }
 

--- a/src/Contracts/Translator.php
+++ b/src/Contracts/Translator.php
@@ -9,24 +9,24 @@ interface Translator
     /**
      * Translate all translated attributes of a model.
      *
-     * @param Model $model
-     * @param array $attributes
-     * @param  string                        $targetLang
-     * @param  string|null                   $sourceLanguage
-     * @param bool $force
+     * @param  Model  $model
+     * @param  array  $attributes
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
+     * @param  bool  $force
      * @return void
      */
-    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null, bool $force = true);
+    public function translate(Model $model, string $targetLang, string|null $sourceLanguage = null, bool $force = true);
 
     /**
      * Translate a list of attributes.
      *
-     * @param Model $model
-     * @param array $attributes
-     * @param  string                        $targetLang
-     * @param  string|null                   $sourceLanguage
-     * @param bool $force
+     * @param  Model  $model
+     * @param  array  $attributes
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
+     * @param  bool  $force
      * @return void
      */
-    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null, bool $force = true);
+    public function translateAttributes(Model $model, array $attributes, string $targetLang, string|null $sourceLanguage = null, bool $force = true);
 }

--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -19,7 +19,7 @@ class Deepl
     /**
      * Create new Deepl instance.
      *
-     * @param string $apiToken
+     * @param  string  $apiToken
      * @return void
      */
     public function __construct(
@@ -33,12 +33,12 @@ class Deepl
     /**
      * Translate a string to a target language with DeepL.
      *
-     * @param  string                     $string
-     * @param  string                     $targetLang
-     * @param  string|null                $sourceLanguage
+     * @param  string  $string
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
      * @return string
      */
-    public function translate(string $string, string $targetLang, string | null $sourceLanguage = null): string
+    public function translate(string $string, string $targetLang, string|null $sourceLanguage = null): string
     {
         // Avoid translating empty strings.
         if (! $string) {
@@ -64,9 +64,9 @@ class Deepl
     /**
      * Send a deepl api call.
      *
-     * @param string $method
-     * @param string $action
-     * @param array $params
+     * @param  string  $method
+     * @param  string  $action
+     * @param  array  $params
      * @return array
      */
     protected function apiCall($method, $action, $params = []): array

--- a/src/Jobs/TranslateModelJob.php
+++ b/src/Jobs/TranslateModelJob.php
@@ -2,13 +2,13 @@
 
 namespace AwStudio\Deeplable\Jobs;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
-use GuzzleHttp\Exception\GuzzleException;
 use AwStudio\Deeplable\Facades\Translator;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
 class TranslateModelJob implements ShouldQueue
 {

--- a/src/Jobs/TranslateModelJob.php
+++ b/src/Jobs/TranslateModelJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AwStudio\Deeplable\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use GuzzleHttp\Exception\GuzzleException;
+use AwStudio\Deeplable\Facades\Translator;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class TranslateModelJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        protected $model,
+        protected $locale,
+        protected $fallbackLocale,
+        protected $force
+    ) {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $translator = Translator::for($this->model);
+        try {
+            $translator->translate($this->model, $this->locale, $this->fallbackLocale, $this->force);
+        } catch (GuzzleException $e) {
+            $this->error('Failed to translate '.get_class($this->model));
+        }
+    }
+}

--- a/src/Traits/Deeplable.php
+++ b/src/Traits/Deeplable.php
@@ -9,12 +9,12 @@ trait Deeplable
     /**
      * Translate the model to a target language.
      *
-     * @param  string      $targetLang
-     * @param  string|null $sourceLanguage
-     * @param bool $force
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
+     * @param  bool  $force
      * @return void
      */
-    public function translateTo(string $targetLang, string | null $sourceLanguage = null, bool $force = true)
+    public function translateTo(string $targetLang, string|null $sourceLanguage = null, bool $force = true)
     {
         Translator::for($this)->translate($this, $targetLang, $sourceLanguage, $force);
 
@@ -24,13 +24,13 @@ trait Deeplable
     /**
      * Translate a model attribute to a target language.
      *
-     * @param  string      $attr
-     * @param  string      $targetLang
-     * @param  string|null $sourceLanguage
-     * @param bool $force
+     * @param  string  $attr
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
+     * @param  bool  $force
      * @return void
      */
-    public function translateAttributeTo(string $attr, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
+    public function translateAttributeTo(string $attr, string $targetLang, string|null $sourceLanguage = null, bool $force = true)
     {
         $this->translateAttributesTo([$attr], $targetLang, $sourceLanguage, $force);
     }
@@ -38,13 +38,13 @@ trait Deeplable
     /**
      * Translate multiple model attributes to a target language.
      *
-     * @param  string      $attr
-     * @param  string      $targetLang
-     * @param  string|null $sourceLanguage
-     * @param bool $force
+     * @param  string  $attr
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
+     * @param  bool  $force
      * @return void
      */
-    public function translateAttributesTo(array $attributes, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
+    public function translateAttributesTo(array $attributes, string $targetLang, string|null $sourceLanguage = null, bool $force = true)
     {
         Translator::for($this)->translateAttributes($this, $attributes, $targetLang, $sourceLanguage);
 

--- a/src/Translators/AstrotomicTranslator.php
+++ b/src/Translators/AstrotomicTranslator.php
@@ -9,11 +9,11 @@ class AstrotomicTranslator extends BaseTranslator
     /**
      * Translate the given model attribute.
      *
-     * @param Model $model
-     * @param string $attribute
-     * @param string $locale
-     * @param string $translation
-     * @param bool $force
+     * @param  Model  $model
+     * @param  string  $attribute
+     * @param  string  $locale
+     * @param  string  $translation
+     * @param  bool  $force
      * @return void
      */
     protected function translateAttribute(Model $model, $attribute, $locale, $translation, bool $force = true)
@@ -31,8 +31,8 @@ class AstrotomicTranslator extends BaseTranslator
     /**
      * Get a list of the translated attributes of a model.
      *
-     * @param Model $model
-     * @param string $locale
+     * @param  Model  $model
+     * @param  string  $locale
      * @return array
      */
     public function getTranslatedAttributes(Model $model, $locale)
@@ -43,14 +43,14 @@ class AstrotomicTranslator extends BaseTranslator
     /**
      * Translate all translated attributes of a model.
      *
-     * @param Model $model
-     * @param array $attributes
-     * @param  string                        $targetLang
-     * @param  string|null                   $sourceLanguage
-     * @param bool $force
+     * @param  Model  $model
+     * @param  array  $attributes
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
+     * @param  bool  $force
      * @return void
      */
-    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
+    public function translate(Model $model, string $targetLang, string|null $sourceLanguage = null, bool $force = true)
     {
         if (! $model->hasTranslation($sourceLanguage)) {
             return;

--- a/src/Translators/BaseTranslator.php
+++ b/src/Translators/BaseTranslator.php
@@ -12,9 +12,9 @@ abstract class BaseTranslator implements Translator
      * Translate the given model attribute.
      *
      * @param  Model  $model
-     * @param  string $attribute
-     * @param  string $locale
-     * @param  string $translation
+     * @param  string  $attribute
+     * @param  string  $locale
+     * @param  string  $translation
      * @return void
      */
     abstract protected function translateAttribute(Model $model, $attribute, $locale, $translation, bool $force = true);
@@ -23,7 +23,7 @@ abstract class BaseTranslator implements Translator
      * Get a list of the translated attributes of a model.
      *
      * @param  Model  $model
-     * @param  string $locale
+     * @param  string  $locale
      * @return array
      */
     abstract public function getTranslatedAttributes(Model $model, $locale);
@@ -31,7 +31,7 @@ abstract class BaseTranslator implements Translator
     /**
      * Create new Translator instance.
      *
-     * @param  Deepl $api
+     * @param  Deepl  $api
      * @return void
      */
     public function __construct(
@@ -43,13 +43,13 @@ abstract class BaseTranslator implements Translator
     /**
      * Translate all translated attributes of a model.
      *
-     * @param  Model       $model
-     * @param  array       $attributes
-     * @param  string      $targetLang
-     * @param  string|null $sourceLanguage
+     * @param  Model  $model
+     * @param  array  $attributes
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
      * @return void
      */
-    public function translate(Model $model, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
+    public function translate(Model $model, string $targetLang, string|null $sourceLanguage = null, bool $force = true)
     {
         $translatedAttributes = $this->getTranslatedAttributes($model, $sourceLanguage);
 
@@ -69,13 +69,13 @@ abstract class BaseTranslator implements Translator
     /**
      * Translate a list of attributes.
      *
-     * @param  Model       $model
-     * @param  array       $attributes
-     * @param  string      $targetLang
-     * @param  string|null $sourceLanguage
+     * @param  Model  $model
+     * @param  array  $attributes
+     * @param  string  $targetLang
+     * @param  string|null  $sourceLanguage
      * @return void
      */
-    public function translateAttributes(Model $model, array $attributes, string $targetLang, string | null $sourceLanguage = null, bool $force = true)
+    public function translateAttributes(Model $model, array $attributes, string $targetLang, string|null $sourceLanguage = null, bool $force = true)
     {
         foreach ($attributes as $attribute) {
             $translation = $this->api->translate(

--- a/src/Translators/Resolver.php
+++ b/src/Translators/Resolver.php
@@ -25,8 +25,8 @@ class Resolver
     /**
      * Register a translator resolver.
      *
-     * @param string $alias
-     * @param Closure $resolver
+     * @param  string  $alias
+     * @param  Closure  $resolver
      * @return void
      */
     public function register($alias, Closure $resolver)
@@ -37,7 +37,7 @@ class Resolver
     /**
      * Get a translator.
      *
-     * @param string $alias
+     * @param  string  $alias
      * @return Translator|null
      */
     public function get($alias)
@@ -56,7 +56,7 @@ class Resolver
     /**
      * Get translator for the given model.
      *
-     * @param Model $model
+     * @param  Model  $model
      * @return Translator|null
      */
     public function for(Model $model)
@@ -69,7 +69,7 @@ class Resolver
     /**
      * Set translation strategy.
      *
-     * @param Closure $closure
+     * @param  Closure  $closure
      * @return void
      */
     public function strategy(Closure $closure)


### PR DESCRIPTION
This PR adds the `queue` option to `deeplable:run` command which, if set to true, dispatches a `TranslateModelJob` in order to relieve the Deepl-API from large sets.