### PR TITLE
Add Laravel 9 support, refs #10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,16 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.3",
-        "illuminate/support": "^9.0",
-        "illuminate/console": "^9.0",
-        "illuminate/database": "^9.0"
+        "illuminate/support": "^8.0|^9.0",
+        "illuminate/console": "^8.0|^9.0",
+        "illuminate/database": "^8.0|^9.0"
     },
     "require-dev": {
         "astrotomic/laravel-translatable": "^11.0",
         "phpunit/phpunit": "^9.4",
         "mockery/mockery": "^1.4",
-        "illuminate/testing": "^9.0",
-        "orchestra/testbench": "^7.0"
+        "illuminate/testing": "^8.0|^9.0",
+        "orchestra/testbench": "^6.0|^7.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,16 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.3",
-        "illuminate/support": "^8",
-        "illuminate/console": "^8.0",
-        "illuminate/database": "^8.0"
+        "illuminate/support": "^9.0",
+        "illuminate/console": "^9.0",
+        "illuminate/database": "^9.0"
     },
     "require-dev": {
         "astrotomic/laravel-translatable": "^11.0",
         "phpunit/phpunit": "^9.4",
         "mockery/mockery": "^1.4",
-        "illuminate/testing": "^8.0",
-        "orchestra/testbench": "^6.0"
+        "illuminate/testing": "^9.0",
+        "orchestra/testbench": "^7.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "larshanskrause/laravel-deeplable",
+    "name": "aw-studio/laravel-deeplable",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "aw-studio/laravel-deeplable",
+    "name": "larshanskrause/laravel-deeplable",
     "license": "MIT",
     "authors": [
         {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite name="Fjord Test Suite">
+        <testsuite name="Tests">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,35 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Tests">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <server name="APP_ENV" value="testing"/>
-        <server name="BCRYPT_ROUNDS" value="4"/>
-        <server name="APP_DEBUG" value="true"/>
-        <server name="CACHE_DRIVER" value="array"/>
-        <server name="DB_CONNECTION" value="sqlite"/>
-        <server name="DB_DATABASE" value=":memory:"/>
-        <server name="MAIL_MAILER" value="array"/>
-        <server name="QUEUE_CONNECTION" value="sync"/>
-        <server name="SESSION_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" beStrictAboutTestsThatDoNotTestAnything="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+	<coverage processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">
+				./src
+			</directory>
+		</include>
+	</coverage>
+	<testsuites>
+		<testsuite name="Tests">
+			<directory suffix="Test.php">
+				./tests
+			</directory>
+		</testsuite>
+	</testsuites>
+	<php>
+		<server name="APP_ENV" value="testing" />
+		<server name="BCRYPT_ROUNDS" value="4" />
+		<server name="APP_DEBUG" value="true" />
+		<server name="CACHE_DRIVER" value="array" />
+		<server name="DB_CONNECTION" value="sqlite" />
+		<server name="DB_DATABASE" value=":memory:" />
+		<server name="MAIL_MAILER" value="array" />
+		<server name="QUEUE_CONNECTION" value="sync" />
+		<server name="SESSION_DRIVER" value="array" />
+	</php>
 </phpunit>

--- a/tests/AstrotomicTranslatorTest.php
+++ b/tests/AstrotomicTranslatorTest.php
@@ -2,36 +2,19 @@
 
 namespace Tests;
 
-use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
-use Astrotomic\Translatable\Translatable;
 use Astrotomic\Translatable\TranslatableServiceProvider;
 use AwStudio\Deeplable\Deepl;
 use AwStudio\Deeplable\Translators\AstrotomicTranslator;
-use Illuminate\Database\Eloquent\Model;
 use Mockery;
-use Orchestra\Testbench\TestCase;
+use Tests\TestSupport\DummyPost;
 
 class AstrotomicTranslatorTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected function getPackageProviders($app)
     {
         return [
             TranslatableServiceProvider::class,
         ];
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
-        $config = $app['config'];
-        $config->set('translatable.fallback_locale', 'en');
-        $config->set('translatable.locales', [
-            'en', 'de',
-        ]);
     }
 
     public function testItTranslatesModelAttributes()
@@ -40,7 +23,7 @@ class AstrotomicTranslatorTest extends TestCase
         $api->shouldReceive('translate')->andReturn('Hallo Welt');
         $translator = new AstrotomicTranslator($api);
 
-        $post = new DummyTranslatablePost([
+        $post = new DummyPost([
             'en' => ['title' => 'Hello World'],
             'de' => ['title' => 'Foo'],
         ]);
@@ -52,7 +35,7 @@ class AstrotomicTranslatorTest extends TestCase
 
         $this->app->setLocale('en');
 
-        $post = new DummyTranslatablePost([
+        $post = new DummyPost([
             'en' => ['title' => 'Hello World'],
             'de' => ['title' => 'Foo'],
         ]);
@@ -69,7 +52,7 @@ class AstrotomicTranslatorTest extends TestCase
         $api->shouldReceive('translate')->andReturn('Hallo Welt');
         $translator = new AstrotomicTranslator($api);
 
-        $post = new DummyTranslatablePost([
+        $post = new DummyPost([
             'en' => ['title' => 'Hello World'],
         ]);
 
@@ -82,7 +65,7 @@ class AstrotomicTranslatorTest extends TestCase
         $api->shouldReceive('translate')->andReturn('Hallo Welt');
         $translator = new AstrotomicTranslator($api);
 
-        $post = new DummyTranslatablePost([
+        $post = new DummyPost([
             'en' => ['title' => 'Hello World'],
             'de' => ['title' => 'Foo'],
         ]);
@@ -92,7 +75,7 @@ class AstrotomicTranslatorTest extends TestCase
         $this->assertSame($post->title, 'Foo');
 
         $this->app->setLocale('en');
-        $post = new DummyTranslatablePost([
+        $post = new DummyPost([
             'en' => ['title' => 'Hello World'],
             'de' => ['title' => 'Foo'],
         ]);
@@ -100,21 +83,4 @@ class AstrotomicTranslatorTest extends TestCase
         $this->app->setLocale('de');
         $this->assertSame($post->title, 'Foo');
     }
-}
-
-class DummyTranslatablePostTranslation extends Model
-{
-    public $table = 'post_translations';
-    protected $fillable = ['title'];
-    public $timestamps = false;
-}
-
-class DummyTranslatablePost extends Model implements TranslatableContract
-{
-    use Translatable;
-
-    public $table = 'posts';
-    protected $translationModel = DummyTranslatablePostTranslation::class;
-    protected $translatedAttributes = ['title'];
-    public $timestamps = false;
 }

--- a/tests/BaseTranslatorTest.php
+++ b/tests/BaseTranslatorTest.php
@@ -65,7 +65,7 @@ class DummyTranslatorMock extends BaseTranslator
     protected function translateAttribute(Model $model, $attribute, $locale, $translation, bool $force = true)
     {
         $this->calledTimes++;
-        $this->calledParams [] = new AssertableJsonString([
+        $this->calledParams[] = new AssertableJsonString([
             'model' => $model,
             'attribute' => $attribute,
             'locale' => $locale,

--- a/tests/DeeplableCommandTest.php
+++ b/tests/DeeplableCommandTest.php
@@ -2,56 +2,18 @@
 
 namespace Tests;
 
-use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
-use Astrotomic\Translatable\Translatable;
 use AwStudio\Deeplable\Deepl;
 use AwStudio\Deeplable\DeeplableServiceProvider;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Mockery;
-use Orchestra\Testbench\TestCase;
+use Tests\TestSupport\DummyPost;
 
 class DeeplableCommandTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-        Schema::create('posts', fn (Blueprint $table) => $table->id());
-        Schema::create('post_translations', function (Blueprint $table) {
-            $table->id();
-            $table->unsignedBigInteger('dummy_post_id');
-            $table->string('locale');
-            $table->string('title');
-        });
-    }
-
-    public function tearDown(): void
-    {
-        Schema::drop('posts');
-        Schema::drop('post_translations');
-        parent::tearDown();
-    }
-
     protected function getPackageProviders($app)
     {
         return [
             DeeplableServiceProvider::class,
         ];
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
-        $config = $app['config'];
-        $config->set('deeplable.api_url', '');
-        $config->set('deeplable.api_token', '');
-        $config->set('deeplable.translated_models', [
-            DummyPost::class,
-        ]);
-        $config->set('translatable.fallback_locale', 'en');
-        $config->set('translatable.locales', [
-            'en', 'de',
-        ]);
     }
 
     public function test_deeplable_run_command()
@@ -121,21 +83,4 @@ class DeeplableCommandTest extends TestCase
             $this->assertSame('bar', $post->title);
         }
     }
-}
-
-class DummyPostTranslation extends Model
-{
-    public $table = 'post_translations';
-    protected $fillable = ['title'];
-    public $timestamps = false;
-}
-
-class DummyPost extends Model implements TranslatableContract
-{
-    use Translatable;
-
-    public $table = 'posts';
-    protected $translationModel = DummyPostTranslation::class;
-    protected $translatedAttributes = ['title'];
-    public $timestamps = false;
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests;
+
+use Orchestra\Testbench\TestCase as BaseTestCase;
+use Tests\TestSupport\DummyPost;
+
+class TestCase extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadMigrationsFrom(__DIR__ . '/TestSupport/database/migrations');
+
+        $this->artisan('migrate', [
+            '--database' => 'testbench',
+        ])->run();
+    }
+
+    public function tearDown(): void
+    {
+        $this->artisan('migrate:reset', [
+            '--database' => 'testbench',
+        ])->run();
+
+        parent::tearDown();
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $config = $app['config'];
+        $config->set('deeplable.api_url', '');
+        $config->set('deeplable.api_token', '');
+        $config->set('deeplable.translated_models', [
+            DummyPost::class,
+        ]);
+        $config->set('translatable.fallback_locale', 'en');
+        $config->set('translatable.locales', [
+            'en', 'de',
+        ]);
+
+        $config->set('database.default', 'testbench');
+        $config->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+}

--- a/tests/TestSupport/DummyPost.php
+++ b/tests/TestSupport/DummyPost.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
+use Astrotomic\Translatable\Translatable;
+
+class DummyPost extends Model implements TranslatableContract
+{
+    use Translatable;
+
+    public $table = 'posts';
+    protected $translationModel = DummyPostTranslation::class;
+    protected $translatedAttributes = ['title'];
+    protected $translationForeignKey = 'post_id';
+    public $timestamps = false;
+}

--- a/tests/TestSupport/DummyPostTranslation.php
+++ b/tests/TestSupport/DummyPostTranslation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyPostTranslation extends Model
+{
+    public $table = 'post_translations';
+    protected $fillable = ['title'];
+    public $timestamps = false;
+}

--- a/tests/TestSupport/database/migrations/2023_09_14_000001_create_posts_table.php
+++ b/tests/TestSupport/database/migrations/2023_09_14_000001_create_posts_table.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+};

--- a/tests/TestSupport/database/migrations/2023_09_14_000002_create_post_translations.php
+++ b/tests/TestSupport/database/migrations/2023_09_14_000002_create_post_translations.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('post_translations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('post_id');
+            $table->string('locale');
+            $table->string('title');
+        });
+    }
+};


### PR DESCRIPTION
- tested it on PHP 8.1
- checked Laravel upgrade guide – no further adjustments required
- tests ran successfully 
- refactored the tests structure a bit, so that they may run independently on the `testbench` database

Open for any critique and input, especially since I do not regularly work on PHP packages.

[My fork](https://github.com/larshanskrause/laravel-deeplable) may be used as [vcs repository](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository) until this is merged.

Refs #10 